### PR TITLE
Add support for importing & exporting graphs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ DEMO_MODULES = \
 	dijkstra_demo \
 	kruskal_demo \
 	flow_demo \
-	a_star_demo
+	a_star_demo \
+	import_export_demo
 
 EDOC_MODULES = \
 	doc \
@@ -69,7 +70,7 @@ edoc: $(TARGETS)
 demo: $(TARGETS)
 	@(./rundemo.rb)
 
-dialyze: $(TARGETS)
+dialyzer: $(TARGETS)
 	dialyzer -n -Wunmatched_returns $(EBIN)/*.beam
 
 clean:

--- a/demo/src/a_star_demo.erl
+++ b/demo/src/a_star_demo.erl
@@ -1,26 +1,22 @@
 -module(a_star_demo).
--export([b1/0]).
+-export([b1/0, dump_vertex/1]).
 
-parse_vertex([$(, X, $,,  Y, $)]) -> {X - $0, Y - $0}.
+%% The representation of a vertex.
+-type my_vertex() :: {integer(), integer()}.
 
 -spec b1() -> ok.
 b1() ->
   File = ?DEMO_DATA ++ "/board1.txt",
-  %% Function to read the vertices
-  ReadVertices =
-    fun(IO, _N) -> 
-      Ln = io:get_line(IO, ">"),
-      Ts = string:tokens(string:strip(Ln, right, $\n), " "),
-      [parse_vertex(T) || T <- Ts]
-    end,
-  %% Function to read each edge
-  ReadEdge =
-    fun(IO, _WT) ->
-      {ok, [V1, V2, W]} = io:fread(IO, ">", "~s ~s ~d"),
-      {parse_vertex(V1), parse_vertex(V2), W}
-    end,
   %% Heurestic underestimate function
   F = fun({X1, Y1}, {X2, Y2}) -> abs(X1 - X2) + abs(Y1 - Y2) end,
-  G = graph:from_file(File, ReadVertices, ReadEdge),
+  G = graph:import(File, fun parse_vertex/1),
   {Cost, Path} = a_star:run(G, {1,1}, {6,6}, F),
   io:format("Cost: ~p~nPath: ~p~n", [Cost, Path]).
+
+%% Parses the string that holds a vertex.
+-spec parse_vertex(string()) -> my_vertex().
+parse_vertex([$(, X, $,, Y, $)]) -> {X - $0, Y - $0}.
+
+%% Dumps a vertex to a string.
+-spec dump_vertex(my_vertex()) -> string().
+dump_vertex({X, Y}) -> [$(, X + $0, $,, Y + $0, $)].

--- a/demo/src/import_export_demo.erl
+++ b/demo/src/import_export_demo.erl
@@ -1,0 +1,17 @@
+-module(import_export_demo).
+-export([f/0]).
+
+-spec f() -> true.
+f() ->
+  G = graph:empty(directed, d),
+  Foo = graph:add_vertex(G, "foo"),
+  Bar = graph:add_vertex(G, "bar"),
+  Baz = graph:add_vertex(G, "baz"),
+  _ = graph:add_edge(G, Foo, Bar, 20),
+  _ = graph:add_edge(G, Bar, Foo, 20),
+  _ = graph:add_edge(G, Bar, Baz, 80),
+  Id = fun(V) -> V end,
+  File = "graph.txt",
+  graph:export(G, File, Id),
+  G1 = graph:import(File, Id),
+  true = graph:equal(G, G1).

--- a/src/graph.erl
+++ b/src/graph.erl
@@ -84,9 +84,9 @@
 -module(graph).
 
 -export([from_file/1, from_file/3, del_graph/1, vertices/1, edges/1, edge_weight/2,
-         edges_with_weights/1, out_neighbours/2, num_of_vertices/1,
-         num_of_edges/1, pprint/1, empty/1, add_vertex/2, add_edge/3,
-         add_edge/4, graph_type/1, del_edge/2]).
+         edges_with_weights/1, out_neighbours/2, num_of_vertices/1, equal/2,
+         num_of_edges/1, pprint/1, empty/1, empty/2, add_vertex/2, add_edge/3,
+         add_edge/4, graph_type/1, del_edge/2, weight_type/1, export/3, import/2]).
 
 -export_type([graph/0, vertex/0, edge/0, weight/0]).
 
@@ -94,7 +94,11 @@
 %% @type graph(). A directed or undirected graph.
 %% <p>It is wrapper for a digraph with the extra information on its type.</p>
 %%
--record(graph, {type :: graphtype(), graph :: digraph:graph()}).
+-record(graph, {
+  type       :: graphtype(),
+  graph      :: digraph:graph(),
+  weightType :: weighttype()
+}).
 -type graph()      :: #graph{}.
 -type vertex()     :: term().
 -type edge()       :: {vertex(), vertex()}.
@@ -103,11 +107,18 @@
 -type weighttype() :: unweighted | d | f.
 
 
-%% @doc Create a new empty graph.
+%% @doc Create a new empty unweighted graph.
 -spec empty(graphtype()) -> graph().
 
 empty(Type) when Type =:= directed; Type =:= undirected ->
-  #graph{type=Type, graph=digraph:new()}.
+  #graph{type=Type, graph=digraph:new(), weightType = unweighted}.
+
+%% @doc Create a new empty graph with a specific weight type.
+-spec empty(graphtype(), weighttype()) -> graph().
+
+empty(T, WT) when (T =:= directed orelse T =:= undirected) andalso
+                  (WT =:= unweighted orelse WT =:= d orelse WT =:= f) ->
+  #graph{type=T, graph=digraph:new(), weightType=WT}.
 
 %% @doc Create a new graph from a file using the default behaviour.
 -spec from_file(file:name()) -> graph().
@@ -115,7 +126,7 @@ empty(Type) when Type =:= directed; Type =:= undirected ->
 from_file(File) ->
   from_file(File, fun read_vertices/2, fun read_edge/2).
 
-%% @doc Create a new graph from a file using a custo behaviour.
+%% @doc Create a new graph from a file using a custom behaviour.
 %% <p>The user must provide the 2 functions for reading the vertices and the
 %% edge descriptions.</p>
 %%
@@ -134,7 +145,7 @@ from_file(File, ReadVertices, ReadEdge) ->
   %% T = Graph Type :: directed | undirected
   %% W = Edge Weight weighted :: Weight Type (d | f) | unweighted
   {ok, [N, M, T, W]} = io:fread(IO, ">", "~d ~d ~a ~a"),
-  G = #graph{type=T, graph=digraph:new()},
+  G = #graph{type=T, graph=digraph:new(), weightType=W},
   ok = init_vertices(IO, G, N, ReadVertices),
   ok = init_edges(IO, G, M, ReadEdge, T, W),
   G.
@@ -155,14 +166,16 @@ read_vertices(_IO, N) -> lists:seq(0, N-1).
 %% <p>W is the number that denotes the weight of the edge.</p>
 -spec read_edge(file:io_device(), weighttype()) -> {vertex(), vertex(), weight()}.
 
-read_edge(IO, unweighted) ->
-  {ok, [V1, V2]} = io:fread(IO, ">", "~d ~d"),
-  {V1, V2, 1};
 read_edge(IO, WT) ->
-  Format = "~d ~d ~" ++ atom_to_list(WT),
-  {ok, [V1, V2, W]} = io:fread(IO, ">", Format),
-  {V1, V2, W}.
+  read_edge(IO, WT, fun erlang:list_to_integer/1).
 
+read_edge(IO, unweighted, MapVertex) ->
+  {ok, [V1, V2]} = io:fread(IO, ">", "~s ~s"),
+  {MapVertex(V1), MapVertex(V2), 1};
+read_edge(IO, WT, MapVertex) ->
+  Format = "~s ~s ~" ++ atom_to_list(WT),
+  {ok, [V1, V2, W]} = io:fread(IO, ">", Format),
+  {MapVertex(V1), MapVertex(V2), W}.
 
 %% Initialize the vertices of the graph
 -spec init_vertices(file:io_device(), graph(), integer(), function()) -> ok.
@@ -188,35 +201,41 @@ del_graph(G) ->
   
 %% @doc Return the type of the graph.
 -spec graph_type(graph()) -> graphtype().
-  
+
 graph_type(G) ->
   G#graph.type.
+
+%% @doc Return the type of the weights.
+-spec weight_type(graph()) -> weighttype().
+
+weight_type(G) ->
+  G#graph.weightType.
 
 %% @doc Add a vertex to a graph
 -spec add_vertex(graph(), vertex()) -> vertex().
 
 add_vertex(G, V) ->
   digraph:add_vertex(G#graph.graph, V).
-  
+
 %% @doc Return a list of the vertices of a graph
 -spec vertices(graph()) -> [vertex()].
-  
+
 vertices(G) ->
   digraph:vertices(G#graph.graph).
 
 %% @doc Return the number of vertices in a graph
 -spec num_of_vertices(graph()) -> non_neg_integer().
-  
+
 num_of_vertices(G) ->
   digraph:no_vertices(G#graph.graph).
-  
+
 %% @doc Add an edge to an unweighted graph.
 %% <p>Create an edge with unit weight/</p>
 -spec add_edge(graph(), vertex(), vertex()) -> edge().
 
 add_edge(G, From, To) ->
   add_edge(G, From, To, 1).
-  
+
 %% @doc Add an edge to a weighted graph
 -spec add_edge(graph(), vertex(), vertex(), weight()) -> edge() | {error, not_numeric_weight}.
 
@@ -228,13 +247,12 @@ add_edge(#graph{type=undirected, graph=G}, From, To, W) when is_number(W) ->
 add_edge(_G, _From, _To, _W) ->
   {error, not_numeric_weight}.
 
-
 %% @doc Delete an edge from a graph
 -spec del_edge(graph(), edge()) -> 'true'.
 
 del_edge(G, E) ->
   digraph:del_edge(G#graph.graph, E).
-  
+
 %% @doc Return a list of the edges of a graph
 -spec edges(graph()) -> [edge()].
 
@@ -260,32 +278,32 @@ num_of_edges(G) ->
     directed -> M;
     undirected -> M div 2
   end.
-  
+
 %% @doc Return the weight of an edge
 -spec edge_weight(graph(), edge()) -> weight() | 'false'.
-  
+
 edge_weight(G, E) ->
   case digraph:edge(G#graph.graph, E) of
     {E, _V1, _V2, W} -> W;
     false -> false
   end.
-  
+
 %% @doc Return a list of the edges of a graph along with their weights
 -spec edges_with_weights(graph()) -> [{edge(), weight()}].
-  
+
 edges_with_weights(G) ->
   Es = edges(G),
   lists:map(fun(E) -> {E, edge_weight(G, E)} end, Es).
-  
+
 %% @doc Return a list of the out neighbours of a vertex
 -spec out_neighbours(graph(), vertex()) -> [vertex()].
   
 out_neighbours(G, V) ->
   digraph:out_neighbours(G#graph.graph, V).
-  
+
 %% @doc Pretty print a graph
 -spec pprint(graph()) -> ok.
-  
+
 pprint(G) ->
   Vs = digraph:vertices(G#graph.graph),
   F = 
@@ -304,3 +322,75 @@ pprint(G) ->
   io:format("========================~n"),
   io:format("~p~n", [N]).
 
+%% @doc Exports a graph to a file.
+%% <p>The user must provide the function that will generate the textual
+%% representation of a vertex.</p>
+%%
+%% <p>DumpVertex will take a vertex and return its textual representation.</p>
+-spec export(graph(), file:name(), fun((vertex()) -> string())) -> ok.
+
+export(Graph, Filename, DumpVertex) ->
+  {ok, IO} = file:open(Filename, [write]),
+  export_graph_info(IO, Graph),
+  export_vertices(IO, Graph, DumpVertex),
+  export_edges(IO, Graph, DumpVertex),
+  file:close(IO).
+
+export_graph_info(IO, Graph) ->
+  N = num_of_vertices(Graph),
+  M = num_of_edges(Graph),
+  GT = graph_type(Graph),
+  WT = weight_type(Graph),
+  io:fwrite(IO, "~w ~w ~w ~w~n", [N, M, GT, WT]).
+
+export_vertices(IO, Graph, DumpVertex) ->
+  Vs = vertices(Graph),
+  Rs = [io_lib:format("~s", [DumpVertex(V)]) || V <- Vs],
+  io:fwrite(IO, "~s~n", [string:join(Rs, " ")]).
+
+export_edges(IO, Graph, DumpVertex) ->
+  Es = edges(Graph),
+  lists:foreach(
+    fun({V1, V2}=E) ->
+        W = edge_weight(Graph, E),
+        io:fwrite(IO, "~s ~s ~w~n", [DumpVertex(V1), DumpVertex(V2), W])
+      end,
+    Es).
+
+%% @doc Imports an exported graph.
+%% <p>The user must provide the function that will parse the textual
+%% representation of a vertex.</p>
+%%
+%% <p>MapVertex will take the textual representation of a vertex and return
+%% the actual vertex.</p>
+-spec import(file:name(), fun((string()) -> vertex())) -> graph().
+import(File, MapVertex) ->
+  ImportVs = fun(IO, _N) -> import_vertices(IO, MapVertex) end,
+  ImportEs = fun(IO, WT) -> read_edge(IO, WT, MapVertex) end,
+  from_file(File, ImportVs, ImportEs).
+
+import_vertices(IO, MapVertex) ->
+  Line = io:get_line(IO, ""),
+  Strip1 = string:strip(Line, right, $\n),
+  Strip2 = string:strip(Strip1, right, $\n),
+  Vs = string:tokens(Strip2, " "),
+  [MapVertex(V) || V <- Vs].
+
+%% @doc Checks if two graphs are equal.
+-spec equal(graph(), graph()) -> boolean().
+equal(G1, G2) ->
+  graph_type(G1) =:= graph_type(G2)
+    andalso weight_type(G1) =:= weight_type(G2)
+    andalso num_of_vertices(G1) =:= num_of_vertices(G2)
+    andalso num_of_edges(G1) =:= num_of_edges(G2)
+    andalso lists:sort(vertices(G1)) =:= lists:sort(vertices(G2))
+    andalso equal_edges(G1, G2).
+
+equal_edges(G1, G2) ->
+  Es1 = lists:sort(edges(G1)),
+  Es2 = lists:sort(edges(G2)),
+  case Es1 =:= Es2 of
+    false -> false;
+    true ->
+      [edge_weight(G1, E) || E <- Es1] =:= [edge_weight(G2, E) || E <- Es2]
+  end.


### PR DESCRIPTION
Export a graph with `graph:export/3` and import it back with `graph:import/2`.

This PR addresses issue #2.
