### PR TITLE
Maxflow ETS leak fix and naive windows makefile

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -1,0 +1,23 @@
+
+all:
+	erlc +native +debug_info +warn_exported_vars +warn_unused_import +warn_missing_spec -DDEMO_DATA=\"demo/data\" -o ebin src/graph.erl
+	erlc +native +debug_info +warn_exported_vars +warn_unused_import +warn_missing_spec -DDEMO_DATA=\"demo/data\" -o ebin src/graph_lib.erl
+	erlc +native +debug_info +warn_exported_vars +warn_unused_import +warn_missing_spec -DDEMO_DATA=\"demo/data\" -o ebin src/dijkstra.erl
+	erlc +native +debug_info +warn_exported_vars +warn_unused_import +warn_missing_spec -DDEMO_DATA=\"demo/data\" -o ebin src/bfs.erl
+	erlc +native +debug_info +warn_exported_vars +warn_unused_import +warn_missing_spec -DDEMO_DATA=\"demo/data\" -o ebin src/dfs.erl
+	erlc +native +debug_info +warn_exported_vars +warn_unused_import +warn_missing_spec -DDEMO_DATA=\"demo/data\" -o ebin src/kruskal.erl
+	erlc +native +debug_info +warn_exported_vars +warn_unused_import +warn_missing_spec -DDEMO_DATA=\"demo/data\" -o ebin src/heap.erl
+	erlc +native +debug_info +warn_exported_vars +warn_unused_import +warn_missing_spec -DDEMO_DATA=\"demo/data\" -o ebin src/union_find.erl
+	erlc +native +debug_info +warn_exported_vars +warn_unused_import +warn_missing_spec -DDEMO_DATA=\"demo/data\" -o ebin src/edmonds_karp.erl
+	erlc +native +debug_info +warn_exported_vars +warn_unused_import +warn_missing_spec -DDEMO_DATA=\"demo/data\" -o ebin src/a_star.erl
+	erlc +native +debug_info +warn_exported_vars +warn_unused_import +warn_missing_spec -DDEMO_DATA=\"demo/data\" -o ebin demo/src/demo.erl
+	erlc +native +debug_info +warn_exported_vars +warn_unused_import +warn_missing_spec -DDEMO_DATA=\"demo/data\" -o ebin demo/src/graph_demo.erl
+	erlc +native +debug_info +warn_exported_vars +warn_unused_import +warn_missing_spec -DDEMO_DATA=\"demo/data\" -o ebin demo/src/heap_demo.erl
+	erlc +native +debug_info +warn_exported_vars +warn_unused_import +warn_missing_spec -DDEMO_DATA=\"demo/data\" -o ebin demo/src/union_find_demo.erl
+	erlc +native +debug_info +warn_exported_vars +warn_unused_import +warn_missing_spec -DDEMO_DATA=\"demo/data\" -o ebin demo/src/bfs_demo.erl
+	erlc +native +debug_info +warn_exported_vars +warn_unused_import +warn_missing_spec -DDEMO_DATA=\"demo/data\" -o ebin demo/src/dfs_demo.erl
+	erlc +native +debug_info +warn_exported_vars +warn_unused_import +warn_missing_spec -DDEMO_DATA=\"demo/data\" -o ebin demo/src/dijkstra_demo.erl
+	erlc +native +debug_info +warn_exported_vars +warn_unused_import +warn_missing_spec -DDEMO_DATA=\"demo/data\" -o ebin demo/src/kruskal_demo.erl
+	erlc +native +debug_info +warn_exported_vars +warn_unused_import +warn_missing_spec -DDEMO_DATA=\"demo/data\" -o ebin demo/src/flow_demo.erl
+	erlc +native +debug_info +warn_exported_vars +warn_unused_import +warn_missing_spec -DDEMO_DATA=\"demo/data\" -o ebin demo/src/a_star_demo.erl
+	erlc +native +debug_info +warn_exported_vars +warn_unused_import +warn_missing_spec -DDEMO_DATA=\"demo/data\" -o ebin demo/src/import_export_demo.erl

--- a/src/edmonds_karp.erl
+++ b/src/edmonds_karp.erl
@@ -57,7 +57,11 @@ run(G, S, T, Mode) when Mode =:= bfs; Mode =:= dfs ->
     directed ->
       {Flow, RN} = init_residual_network(G),
       ok = edmonds_karp_step(G, RN, Flow, S, T, Mode),
-      graph_lib:reconstruct_flow(ets:tab2list(Flow));
+      Out = graph_lib:reconstruct_flow(ets:tab2list(Flow)),
+      %% clean up residual graph and flow list
+      graph:del_graph(RN),
+      ets:delete(Flow),
+      Out;
     undirected ->
       {error, not_network}
   end.


### PR DESCRIPTION
Fixes a ETS leak in Maxflow algorithm where one ETS table and one graph wasn't getting deleted after usage. Total of 4 ETS tables leaked per run.

Very basic Makefile for Windows. Enough for automated build tools like `mix` to be able to build this as a dependency. 
